### PR TITLE
implemented request properties (vcChoice) for authentication and signing

### DIFF
--- a/src/main/java/ee/sk/smartid/AuthenticationRequestBuilder.java
+++ b/src/main/java/ee/sk/smartid/AuthenticationRequestBuilder.java
@@ -269,6 +269,19 @@ public class AuthenticationRequestBuilder extends SmartIdRequestBuilder {
   }
 
   /**
+   * Sets the request's request properties
+   * <p>
+   * Optional. Additional request properties
+   *
+   * @param requestProperties request properties of the request
+   * @return this builder
+   */
+  protected AuthenticationRequestBuilder withRequestProperties(RequestProperties requestProperties) {
+    super.withRequestProperties(requestProperties);
+    return this;
+  }
+
+  /**
    * Send the authentication request and get the response
    * <p>
    * This method uses automatic session status polling internally
@@ -393,6 +406,7 @@ public class AuthenticationRequestBuilder extends SmartIdRequestBuilder {
     request.setHash(getHashInBase64());
     request.setDisplayText(getDisplayText());
     request.setNonce(getNonce());
+    request.setRequestProperties(getRequestProperties());
     return request;
   }
 

--- a/src/main/java/ee/sk/smartid/SignatureRequestBuilder.java
+++ b/src/main/java/ee/sk/smartid/SignatureRequestBuilder.java
@@ -231,6 +231,19 @@ public class SignatureRequestBuilder extends SmartIdRequestBuilder {
   }
 
   /**
+   * Sets the request's request properties
+   * <p>
+   * Optional. Additional request properties
+   *
+   * @param requestProperties request properties of the request
+   * @return this builder
+   */
+  public SignatureRequestBuilder withRequestProperties(RequestProperties requestProperties) {
+    super.withRequestProperties(requestProperties);
+    return this;
+  }
+
+  /**
    * Send the signature request and get the response
    * <p>
    * This method uses automatic session status polling internally
@@ -339,6 +352,7 @@ public class SignatureRequestBuilder extends SmartIdRequestBuilder {
     request.setHash(getHashInBase64());
     request.setDisplayText(getDisplayText());
     request.setNonce(getNonce());
+    request.setRequestProperties(getRequestProperties());
     return request;
   }
 }

--- a/src/main/java/ee/sk/smartid/SmartIdRequestBuilder.java
+++ b/src/main/java/ee/sk/smartid/SmartIdRequestBuilder.java
@@ -30,6 +30,7 @@ import ee.sk.smartid.exception.*;
 import ee.sk.smartid.rest.SessionStatusPoller;
 import ee.sk.smartid.rest.SmartIdConnector;
 import ee.sk.smartid.rest.dao.NationalIdentity;
+import ee.sk.smartid.rest.dao.RequestProperties;
 import ee.sk.smartid.rest.dao.SemanticsIdentifier;
 import ee.sk.smartid.rest.dao.SessionResult;
 import org.slf4j.Logger;
@@ -54,6 +55,7 @@ public abstract class SmartIdRequestBuilder {
   private SignableHash hashToSign;
   private String nonce;
   private String displayText;
+  private RequestProperties requestProperties;
 
   protected SmartIdRequestBuilder(SmartIdConnector connector, SessionStatusPoller sessionStatusPoller) {
     this.connector = connector;
@@ -124,6 +126,11 @@ public abstract class SmartIdRequestBuilder {
 
   protected SmartIdRequestBuilder withDisplayText(String displayText) {
     this.displayText = displayText;
+    return this;
+  }
+
+  protected SmartIdRequestBuilder withRequestProperties(RequestProperties requestProperties) {
+    this.requestProperties = requestProperties;
     return this;
   }
 
@@ -236,4 +243,8 @@ public abstract class SmartIdRequestBuilder {
   }
 
   public SemanticsIdentifier getSemanticsIdentifier() { return semanticsIdentifier; }
+
+  public RequestProperties getRequestProperties() {
+    return requestProperties;
+  }
 }

--- a/src/main/java/ee/sk/smartid/rest/dao/AuthenticationSessionRequest.java
+++ b/src/main/java/ee/sk/smartid/rest/dao/AuthenticationSessionRequest.java
@@ -42,6 +42,8 @@ public class AuthenticationSessionRequest implements Serializable {
   private String displayText;
   @JsonInclude(JsonInclude.Include.NON_EMPTY)
   private String nonce;
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  private RequestProperties requestProperties;
 
   public String getCertificateLevel() {
     return certificateLevel;
@@ -97,5 +99,13 @@ public class AuthenticationSessionRequest implements Serializable {
 
   public void setNonce(String nonce) {
     this.nonce = nonce;
+  }
+
+  public RequestProperties getRequestProperties() {
+    return requestProperties;
+  }
+
+  public void setRequestProperties(RequestProperties requestProperties) {
+    this.requestProperties = requestProperties;
   }
 }

--- a/src/main/java/ee/sk/smartid/rest/dao/RequestProperties.java
+++ b/src/main/java/ee/sk/smartid/rest/dao/RequestProperties.java
@@ -1,0 +1,23 @@
+package ee.sk.smartid.rest.dao;
+
+import java.io.Serializable;
+
+public class RequestProperties implements Serializable {
+
+  private boolean vcChoice;
+
+  public boolean isVcChoice() {
+    return vcChoice;
+  }
+
+  public void setVcChoice(boolean vcChoice) {
+    this.vcChoice = vcChoice;
+  }
+
+  @Override
+  public String toString() {
+    return "RequestProperties{" +
+            "vcChoice='" + vcChoice + '\'' +
+            '}';
+  }
+}

--- a/src/main/java/ee/sk/smartid/rest/dao/SessionStatus.java
+++ b/src/main/java/ee/sk/smartid/rest/dao/SessionStatus.java
@@ -38,6 +38,7 @@ public class SessionStatus implements Serializable {
   private SessionSignature signature;
 
   private SessionCertificate cert;
+  private String[] ignoredProperties;
 
   public String getState() {
     return state;
@@ -69,5 +70,13 @@ public class SessionStatus implements Serializable {
 
   public void setSignature(SessionSignature signature) {
     this.signature = signature;
+  }
+
+  public String[] getIgnoredProperties() {
+    return ignoredProperties;
+  }
+
+  public void setIgnoredProperties(String[] ignoredProperties) {
+    this.ignoredProperties = ignoredProperties;
   }
 }

--- a/src/main/java/ee/sk/smartid/rest/dao/SignatureSessionRequest.java
+++ b/src/main/java/ee/sk/smartid/rest/dao/SignatureSessionRequest.java
@@ -42,6 +42,8 @@ public class SignatureSessionRequest implements Serializable {
   private String displayText;
   @JsonInclude(JsonInclude.Include.NON_EMPTY)
   private String nonce;
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  private RequestProperties requestProperties;
 
   public String getCertificateLevel() {
     return certificateLevel;
@@ -97,5 +99,13 @@ public class SignatureSessionRequest implements Serializable {
 
   public void setNonce(String nonce) {
     this.nonce = nonce;
+  }
+
+  public RequestProperties getRequestProperties() {
+    return requestProperties;
+  }
+
+  public void setRequestProperties(RequestProperties requestProperties) {
+    this.requestProperties = requestProperties;
   }
 }

--- a/src/test/java/ee/sk/smartid/AuthenticationRequestBuilderTest.java
+++ b/src/test/java/ee/sk/smartid/AuthenticationRequestBuilderTest.java
@@ -95,6 +95,31 @@ public class AuthenticationRequestBuilderTest {
   }
 
   @Test
+  public void authenticateWithHash_andRequestProperties() throws Exception {
+    AuthenticationHash authenticationHash = new AuthenticationHash();
+    authenticationHash.setHashInBase64("7iaw3Ur350mqGo7jwQrpkj9hiYB3Lkc/iBml1JQODbJ6wYX4oOHV+E+IvIh/1nsUNzLDBMxfqa2Ob1f1ACio/w==");
+    authenticationHash.setHashType(HashType.SHA512);
+
+    RequestProperties requestProperties = new RequestProperties();
+    requestProperties.setVcChoice(true);
+
+    SmartIdAuthenticationResponse authenticationResponse = builder
+            .withRelyingPartyUUID("relying-party-uuid")
+            .withRelyingPartyName("relying-party-name")
+            .withCertificateLevel("QUALIFIED")
+            .withAuthenticationHash(authenticationHash)
+            .withDocumentNumber("PNOEE-31111111111")
+            .withRequestProperties(requestProperties)
+            .authenticate();
+
+    assertCorrectAuthenticationRequestMadeWithDocumentNumber("7iaw3Ur350mqGo7jwQrpkj9hiYB3Lkc/iBml1JQODbJ6wYX4oOHV+E+IvIh/1nsUNzLDBMxfqa2Ob1f1ACio/w==", "QUALIFIED");
+    assertCorrectSessionRequestMade();
+    assertAuthenticationResponseCorrect(authenticationResponse, "7iaw3Ur350mqGo7jwQrpkj9hiYB3Lkc/iBml1JQODbJ6wYX4oOHV+E+IvIh/1nsUNzLDBMxfqa2Ob1f1ACio/w==");
+    assertNotNull(connector.authenticationSessionRequestUsed.getRequestProperties());
+    assertEquals(true, connector.authenticationSessionRequestUsed.getRequestProperties().isVcChoice());
+  }
+
+  @Test
   public void authenticateUsingNationalIdentityNumberAndCountryCode() throws Exception {
     AuthenticationHash authenticationHash = new AuthenticationHash();
     authenticationHash.setHashInBase64("7iaw3Ur350mqGo7jwQrpkj9hiYB3Lkc/iBml1JQODbJ6wYX4oOHV+E+IvIh/1nsUNzLDBMxfqa2Ob1f1ACio/w==");

--- a/src/test/java/ee/sk/smartid/SignatureRequestBuilderTest.java
+++ b/src/test/java/ee/sk/smartid/SignatureRequestBuilderTest.java
@@ -31,6 +31,7 @@ import ee.sk.smartid.exception.TechnicalErrorException;
 import ee.sk.smartid.exception.UserRefusedException;
 import ee.sk.smartid.rest.SessionStatusPoller;
 import ee.sk.smartid.rest.SmartIdConnectorSpy;
+import ee.sk.smartid.rest.dao.RequestProperties;
 import ee.sk.smartid.rest.dao.SessionSignature;
 import ee.sk.smartid.rest.dao.SessionStatus;
 import ee.sk.smartid.rest.dao.SignatureSessionResponse;
@@ -92,6 +93,30 @@ public class SignatureRequestBuilderTest {
     assertCorrectSignatureRequestMade("QUALIFIED");
     assertCorrectSessionRequestMade();
     assertSignatureCorrect(signature);
+  }
+
+  @Test
+  public void signWithSignableData_andRequestProperties() {
+    SignableData dataToSign = new SignableData("Say 'hello' to my little friend!".getBytes());
+    dataToSign.setHashType(HashType.SHA256);
+
+    RequestProperties requestProperties = new RequestProperties();
+    requestProperties.setVcChoice(true);
+
+    SmartIdSignature signature = builder
+            .withRelyingPartyUUID("relying-party-uuid")
+            .withRelyingPartyName("relying-party-name")
+            .withCertificateLevel("QUALIFIED")
+            .withSignableData(dataToSign)
+            .withDocumentNumber("PNOEE-31111111111")
+            .withRequestProperties(requestProperties)
+            .sign();
+
+    assertCorrectSignatureRequestMade("QUALIFIED");
+    assertCorrectSessionRequestMade();
+    assertSignatureCorrect(signature);
+    assertNotNull(connector.signatureSessionRequestUsed.getRequestProperties());
+    assertEquals(true, connector.signatureSessionRequestUsed.getRequestProperties().isVcChoice());
   }
 
   @Test

--- a/src/test/java/ee/sk/smartid/rest/SmartIdRestConnectorTest.java
+++ b/src/test/java/ee/sk/smartid/rest/SmartIdRestConnectorTest.java
@@ -72,6 +72,17 @@ public class SmartIdRestConnectorTest {
   }
 
   @Test
+  public void getRunningSessionStatus_withIgnoredProperties() throws Exception {
+    SessionStatus sessionStatus = getStubbedSessionStatusWithResponse("responses/sessionStatusRunningWithIgnoredProperties.json");
+    assertNotNull(sessionStatus);
+    assertEquals("RUNNING", sessionStatus.getState());
+    assertNotNull(sessionStatus.getIgnoredProperties());
+    assertEquals(2, sessionStatus.getIgnoredProperties().length);
+    assertEquals("testingIgnored", sessionStatus.getIgnoredProperties()[0]);
+    assertEquals("testingIgnoredTwo", sessionStatus.getIgnoredProperties()[1]);
+  }
+
+  @Test
   public void getSessionStatus_forSuccessfulCertificateRequest() throws Exception {
     SessionStatus sessionStatus = getStubbedSessionStatusWithResponse("responses/sessionStatusForSuccessfulCertificateRequest.json");
     assertSuccessfulResponse(sessionStatus);
@@ -235,6 +246,20 @@ public class SmartIdRestConnectorTest {
     assertEquals("2c52caf4-13b0-41c4-bdc6-aa268403cc00", response.getSessionID());
   }
 
+  @Test
+  public void sign_withRequestProperties_usingDocumentNumber() throws Exception {
+    stubRequestWithResponse("/signature/document/PNOEE-123456", "requests/signatureSessionRequestWithRequestProperties.json", "responses/signatureSessionResponse.json");
+    SignatureSessionRequest request = createDummySignatureSessionRequest();
+
+    RequestProperties requestProperties = new RequestProperties();
+    requestProperties.setVcChoice(true);
+    request.setRequestProperties(requestProperties);
+
+    SignatureSessionResponse response = connector.sign("PNOEE-123456", request);
+    assertNotNull(response);
+    assertEquals("2c52caf4-13b0-41c4-bdc6-aa268403cc00", response.getSessionID());
+  }
+
   @Test(expected = UserAccountNotFoundException.class)
   public void sign_whenDocumentNumberNotFound_shouldThrowException() throws Exception {
     stubNotFoundResponse("/signature/document/PNOEE-123456", "requests/signatureSessionRequest.json");
@@ -333,6 +358,35 @@ public class SmartIdRestConnectorTest {
     stubRequestWithResponse("/authentication/document/PNOEE-123456", "requests/authenticationSessionRequestWithDisplayText.json", "responses/authenticationSessionResponse.json");
     AuthenticationSessionRequest request = createDummyAuthenticationSessionRequest();
     request.setDisplayText("Log into internet banking system");
+    AuthenticationSessionResponse response = connector.authenticate("PNOEE-123456", request);
+    assertNotNull(response);
+    assertEquals("1dcc1600-29a6-4e95-a95c-d69b31febcfb", response.getSessionID());
+  }
+
+  @Test
+  public void authenticate_withRequestProperties_usingNationalIdentityNumber() throws Exception {
+    stubRequestWithResponse("/authentication/pno/EE/123456789", "requests/authenticationSessionRequestWithRequestProperties.json", "responses/authenticationSessionResponse.json");
+    NationalIdentity identity = new NationalIdentity("EE", "123456789");
+    AuthenticationSessionRequest request = createDummyAuthenticationSessionRequest();
+
+    RequestProperties requestProperties = new RequestProperties();
+    requestProperties.setVcChoice(true);
+    request.setRequestProperties(requestProperties);
+
+    AuthenticationSessionResponse response = connector.authenticate(identity, request);
+    assertNotNull(response);
+    assertEquals("1dcc1600-29a6-4e95-a95c-d69b31febcfb", response.getSessionID());
+  }
+
+  @Test
+  public void authenticate_withRequestProperties_usingDocumentNumber() throws Exception {
+    stubRequestWithResponse("/authentication/document/PNOEE-123456", "requests/authenticationSessionRequestWithRequestProperties.json", "responses/authenticationSessionResponse.json");
+    AuthenticationSessionRequest request = createDummyAuthenticationSessionRequest();
+
+    RequestProperties requestProperties = new RequestProperties();
+    requestProperties.setVcChoice(true);
+    request.setRequestProperties(requestProperties);
+
     AuthenticationSessionResponse response = connector.authenticate("PNOEE-123456", request);
     assertNotNull(response);
     assertEquals("1dcc1600-29a6-4e95-a95c-d69b31febcfb", response.getSessionID());

--- a/src/test/resources/requests/authenticationSessionRequestWithRequestProperties.json
+++ b/src/test/resources/requests/authenticationSessionRequestWithRequestProperties.json
@@ -1,0 +1,10 @@
+{
+  "relyingPartyUUID": "de305d54-75b4-431b-adb2-eb6b9e546014",
+  "relyingPartyName": "BANK123",
+  "certificateLevel": "ADVANCED",
+  "hash": "K74MSLkafRuKZ1Ooucvh2xa4Q3nz+R/hFWIShN96SPHNcem+uQ6mFMe9kkJQqp5EaoZnJeaFpl310TmlzRgNyQ==",
+  "hashType": "SHA512",
+  "requestProperties": {
+    "vcChoice": true
+  }
+}

--- a/src/test/resources/requests/signatureSessionRequestWithRequestProperties.json
+++ b/src/test/resources/requests/signatureSessionRequestWithRequestProperties.json
@@ -1,0 +1,10 @@
+{
+  "relyingPartyUUID": "de305d54-75b4-431b-adb2-eb6b9e546014",
+  "relyingPartyName": "BANK123",
+  "certificateLevel": "ADVANCED",
+  "hash": "0nbgC2fVdLVQFZJdBbmG7oPoElpCYsQMtrY0c0wKYRg=",
+  "hashType": "SHA256",
+  "requestProperties": {
+    "vcChoice": true
+  }
+}

--- a/src/test/resources/responses/sessionStatusRunningWithIgnoredProperties.json
+++ b/src/test/resources/responses/sessionStatusRunningWithIgnoredProperties.json
@@ -1,0 +1,5 @@
+{
+  "state": "RUNNING",
+  "result": {},
+  "ignoredProperties":["testingIgnored","testingIgnoredTwo"]
+}


### PR DESCRIPTION
Tests added to SmartIdRestIntegrationTest pass but in the app the verification code choice was only available when passing (new) document number that had not passed the choice before.
To test this I temporarily removed the @Ignored and changed document number.