### PR TITLE
switch back to jdk8 for publishing and owasp/spotbugs checking

### DIFF
--- a/travis.sh
+++ b/travis.sh
@@ -7,11 +7,11 @@ echo "Is pull request: $TRAVIS_PULL_REQUEST"
 echo "Tag:             $TRAVIS_TAG"
 echo "JDK version:     $TRAVIS_JDK_VERSION"
 
-if [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_TAG" != "" ] && [ "$TRAVIS_JDK_VERSION" == "openjdk11" ]; then
+if [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_TAG" != "" ] && [ "$TRAVIS_JDK_VERSION" == "openjdk8" ]; then
   echo "Starting to publish"
   ./publish.sh
   echo "Finished"
-elif [ "$TRAVIS_JDK_VERSION" == "openjdk11" ]; then
+elif [ "$TRAVIS_JDK_VERSION" == "openjdk8" ]; then
   ./mvnw test
   ./mvnw org.owasp:dependency-check-maven:check
   ./mvnw spotbugs:check


### PR DESCRIPTION
* cannot make publishing with jdk work without changing program code (which is not possible in bugfix release)