### PR TITLE
SLIB-13 non-Baltic countries date-of-birth parsing caused error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [2.1.4] - Upcoming
+
+### Fixed
+- bug where non-Baltic certificates without date-of-birth resulted with an exception
+
 ## [2.1.3] - 2021-12-22
 
 ### Fixed

--- a/src/main/java/ee/sk/smartid/AuthenticationResponseValidator.java
+++ b/src/main/java/ee/sk/smartid/AuthenticationResponseValidator.java
@@ -299,7 +299,7 @@ public class AuthenticationResponseValidator {
     }
   }
 
-  private static LocalDate getDateOfBirth(AuthenticationIdentity identity) {
+  public static LocalDate getDateOfBirth(AuthenticationIdentity identity) {
     return Optional.ofNullable(
             CertificateAttributeUtil.getDateOfBirth(identity.getAuthCertificate()))
             .orElse(NationalIdentityNumberUtil.getDateOfBirth(identity));

--- a/src/main/java/ee/sk/smartid/util/NationalIdentityNumberUtil.java
+++ b/src/main/java/ee/sk/smartid/util/NationalIdentityNumberUtil.java
@@ -17,14 +17,17 @@ public class NationalIdentityNumberUtil {
             .withResolverStyle(ResolverStyle.STRICT);
 
     /**
-     * Detect date-of-birth from national identification number if possible or return null.
+     * Detect date-of-birth from a Baltic national identification number if possible or return null.
      *
      * This method always returns the value for all Estonian and Lithuanian national identification numbers.
      *
      * It also works for older Latvian personal codes but Latvian personal codes issued after July 1st 2017
      * (starting with "32") do not carry date-of-birth.
      *
-     * Some (but not all) Smart-ID certificates have date-of-birth on a separate attribute.
+     * For non-Baltic countries (countries other than Estonia, Latvia or Lithuania) it always returns null
+     * (even if it would be possible to deduce date of birth from national identity number).
+     *
+     * Newer (but not all) Smart-ID certificates have date-of-birth on a separate attribute.
      * It is recommended to use that value if present.
      * @see CertificateAttributeUtil#getDateOfBirth(java.security.cert.X509Certificate)
      *
@@ -41,7 +44,7 @@ public class NationalIdentityNumberUtil {
             case "LV":
                 return parseLvDateOfBirth(identityNumber);
             default:
-                throw new UnprocessableSmartIdResponseException("Unknown country: " + authenticationIdentity.getCountry());
+                return null;
         }
     }
 

--- a/src/test/java/ee/sk/smartid/util/NationalIdentityNumberUtilTest.java
+++ b/src/test/java/ee/sk/smartid/util/NationalIdentityNumberUtilTest.java
@@ -96,4 +96,22 @@ public class NationalIdentityNumberUtilTest {
         assertThat(exception.getMessage(), is("Unable get birthdate from Latvian personal code 331265-0234"));
     }
 
+    @Test
+    public void getDateOfBirthFromIdCode_sweden_returnsNull() {
+        AuthenticationIdentity identity = new AuthenticationIdentity();
+        identity.setCountry("SE");
+        identity.setIdentityNumber("1995012-79039");
+
+        assertThat(NationalIdentityNumberUtil.getDateOfBirth(identity), is(nullValue()));
+    }
+
+    @Test
+    public void getDateOfBirthFromIdCode_poland_returnsNull() {
+        AuthenticationIdentity identity = new AuthenticationIdentity();
+        identity.setCountry("PL");
+        identity.setIdentityNumber("64120301283");
+
+        assertThat(NationalIdentityNumberUtil.getDateOfBirth(identity), is(nullValue()));
+    }
+
 }


### PR DESCRIPTION
Fix: Authentication result validation fails when Smart-ID user account is not from baltics (EE,LV,LT)